### PR TITLE
Feature/dependency update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 PATH
   remote: .
   specs:
-    tangocard (4.0.0)
+    tangocard (4.1.0)
       httparty (~> 0.11)
-      i18n (~> 0.6.11)
+      i18n (~> 0.7)
       money (~> 6.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    httparty (0.13.3)
+    httparty (0.13.5)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    i18n (0.6.11)
-    json (1.8.2)
-    money (6.5.1)
+    i18n (0.7.0)
+    json (1.8.3)
+    money (6.6.1)
       i18n (>= 0.6.4, <= 0.7.0)
     multi_xml (0.5.5)
     rr (0.10.11)
@@ -35,3 +35,6 @@ DEPENDENCIES
   rr (~> 0)
   rspec (~> 2.14.1)
   tangocard!
+
+BUNDLED WITH
+   1.10.6

--- a/tangocard.gemspec
+++ b/tangocard.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'httparty', '~> 0.11'
   s.add_dependency 'money', '~> 6.1'
-  s.add_dependency 'i18n', '~> 0.6.11'
+  s.add_dependency 'i18n', '~> 0.7'
   s.add_development_dependency 'rspec', '~> 2.14.1'
   s.add_development_dependency 'rr', '~> 0'
 end


### PR DESCRIPTION
i18n ~> 0.6.11 dependency is too restrictive and results in conflicts with rails 4.2 which requires >= 0.7.0