### PR TITLE
custom exceptions now inherit from StandardError

### DIFF
--- a/lib/tangocard/account_create_failed_exception.rb
+++ b/lib/tangocard/account_create_failed_exception.rb
@@ -1,3 +1,3 @@
-class Tangocard::AccountCreateFailedException < Exception
+class Tangocard::AccountCreateFailedException < StandardError
 
 end

--- a/lib/tangocard/account_delete_credit_card_failed_exception.rb
+++ b/lib/tangocard/account_delete_credit_card_failed_exception.rb
@@ -1,3 +1,3 @@
-class Tangocard::AccountDeleteCreditCardFailedException < Exception
+class Tangocard::AccountDeleteCreditCardFailedException < StandardError
 
 end

--- a/lib/tangocard/account_fund_failed_exception.rb
+++ b/lib/tangocard/account_fund_failed_exception.rb
@@ -1,3 +1,3 @@
-class Tangocard::AccountFundFailedException < Exception
+class Tangocard::AccountFundFailedException < StandardError
 
 end

--- a/lib/tangocard/account_not_found_exception.rb
+++ b/lib/tangocard/account_not_found_exception.rb
@@ -1,3 +1,3 @@
-class Tangocard::AccountNotFoundException < Exception
+class Tangocard::AccountNotFoundException < StandardError
 
 end

--- a/lib/tangocard/account_register_credit_card_failed_exception.rb
+++ b/lib/tangocard/account_register_credit_card_failed_exception.rb
@@ -1,3 +1,3 @@
-class Tangocard::AccountRegisterCreditCardFailedException < Exception
+class Tangocard::AccountRegisterCreditCardFailedException < StandardError
 
 end

--- a/lib/tangocard/order_create_failed_exception.rb
+++ b/lib/tangocard/order_create_failed_exception.rb
@@ -1,3 +1,3 @@
-class Tangocard::OrderCreateFailedException < Exception
+class Tangocard::OrderCreateFailedException < StandardError
 
 end

--- a/lib/tangocard/order_not_found_exception.rb
+++ b/lib/tangocard/order_not_found_exception.rb
@@ -1,3 +1,3 @@
-class Tangocard::OrderNotFoundException < Exception
+class Tangocard::OrderNotFoundException < StandardError
 
 end


### PR DESCRIPTION
Inheriting from StandardError is recommended, as inheriting from Exception can cause very bad things to happen.