### PR TITLE
implement cache expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ There are three required configuration parameters:
  * `key` - The API account key you receive from Tango Card
  * `base_uri` - This defaults to the Tango Card sandbox.  For production, you must specify the base URI for the production RaaS API. Make sure not to include `/raas/v1` or any trailing slashes.
 
-There are also three optional configuration parameters:
+There are also optional configuration parameters:
 
  * `default_brands` - An array of strings for the brands you want to retrieve with `Tangocard::Brand.default`. The strings should match the unique brand `description` fields exactly.
  * `local_images` - An array of local image names/URIs that you want to display instead of the default Tango Card-provided `image_url`. `image_url` is sometimes blank, so this can be handy in those cases.
  * `sku_blacklist` - Reward SKUs that are blacklisted, ie. should never be returned as a purchasable reward.
+ * `use_cache` - Use cache for Tangocard::Brand queries, defaults to `true`.
+ * `cache_ttl` - Cache time-to-Live in seconds, only effective if `use_cache` is enabled. Default is `0` (cache never expires).
 
 ## Getting Started
 

--- a/lib/tangocard.rb
+++ b/lib/tangocard.rb
@@ -4,7 +4,8 @@ require 'ostruct'
 
 module Tangocard
   class Configuration
-    attr_accessor :name, :key, :base_uri, :default_brands, :local_images, :sku_blacklist, :use_cache
+    attr_accessor :name, :key, :base_uri, :default_brands, :local_images, :sku_blacklist,
+                  :use_cache, :cache_ttl
 
     def initialize
       self.name = nil
@@ -14,6 +15,7 @@ module Tangocard
       self.local_images = {}
       self.sku_blacklist = []
       self.use_cache = true
+      self.cache_ttl = 0
     end
   end
 

--- a/lib/tangocard/raas.rb
+++ b/lib/tangocard/raas.rb
@@ -1,6 +1,8 @@
 class Tangocard::Raas
   include HTTParty
 
+  @@rewards_response_expires_at = 0
+
   # Create a new account. Returns Tangocard::Response object.
   #
   # Example:
@@ -71,7 +73,11 @@ class Tangocard::Raas
   #   none
   def self.rewards_index
     if Tangocard.configuration.use_cache
+      clear_cache! if cache_expired?
+
       @@rewards_response ||= Tangocard::Response.new(get(endpoint + '/rewards', basic_auth_param))
+      @@rewards_response_expires_at = (Time.now.to_i + Tangocard.configuration.cache_ttl) if cache_expired?
+      @@rewards_response
     else
       Tangocard::Response.new(get(endpoint + '/rewards', basic_auth_param))
     end
@@ -123,12 +129,21 @@ class Tangocard::Raas
 
   def self.clear_cache!
     @@rewards_response = nil
+    @@rewards_response_expires_at = 0
   end
 
   private
 
   def self.basic_auth_param
     {:basic_auth => {:username => Tangocard.configuration.name, :password => Tangocard.configuration.key}}
+  end
+
+  def self.use_cache_ttl?
+    Tangocard.configuration.use_cache && Tangocard.configuration.cache_ttl > 0
+  end
+
+  def self.cache_expired?
+    use_cache_ttl? && @@rewards_response_expires_at < Time.now.to_i
   end
 
   def self.endpoint


### PR DESCRIPTION
The idea here is to automatically expire brands and exchange rates. I know it's possible to call `clear_cache!` from my app but in that case I'll need external tracking when last time cache was cleared, when running multi-instance deployment that's addition work to do.

I my case we need to make sure cards are up-to-date as well as exchange rates. A lot of our users are from Europe and Australia but Tangocard charge in US dollars so I need to represent real value in USD for billing purpose. Tangocard docs says that they update exchange rates daily so I use `cache_ttl = 1.day` in my rails app.

Every time when I need to access tangocard list I call helper method:

```ruby
module Admin::RewardsHelper
  def tangocard_options
    Tangocard::ExchangeRate.populate_money_rates
    Tangocard::Brand.all.map { |brand| tangocard_brand_optgroup(brand) }
  end

  private

  def tangocard_brand_optgroup(brand)
    [ brand.description, brand.rewards.map { |reward| tangocard_reward_option(reward, brand.image_url) } ]
  end

  def tangocard_reward_option(reward, image_url)
    data = { is_variable: reward.is_variable, countries: reward.countries.join(','), currency: reward.currency_code }
    data[:image_url] = image_url unless image_url.blank?
    data[:cost] = reward.denomination unless reward.denomination.zero?
    data[:rate] = Tangocard::ExchangeRate.find(reward.currency_code).inverse_rate
    begin
      data[:cost_usd] = reward.to_money(:denomination).as_us_dollar.cents unless reward.denomination.zero?
    rescue Money::Bank::UnknownRate
    end

    [reward.description, reward.sku, data: data]
  end
end
```

Based on data above it builds nice UI form:
![screen shot 2016-04-15 at 22 40 37](https://cloud.githubusercontent.com/assets/436912/14573143/cf90c656-035b-11e6-9417-291dce9ce22b.png)

I use this code for 3 weeks in production, it works as expected.

Also I think it's a nice helper example with ExchangeRates maybe include in Readme or Wiki?